### PR TITLE
Behebt Bundler Warnung und viewport Fehler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "rake"
 gem "nanoc"

--- a/layouts/header.html
+++ b/layouts/header.html
@@ -1,19 +1,19 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <!--[if lt IE 7 ]> <html lang="en" class="no-js ie6 web-development"> <![endif]-->
 <!--[if IE 7 ]>    <html lang="en" class="no-js ie7 web-development"> <![endif]-->
 <!--[if IE 8 ]>    <html lang="en" class="no-js ie8 web-development"> <![endif]-->
 <!--[if IE 9 ]>    <html lang="en" class="no-js ie9 web-development"> <![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!--> <html lang="en" class="no-js web-development"> <!--<![endif]-->
-<head> 
+<head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
   <title>Lehrbuch Web-Development - <%= @item[:title] %></title>
-   
-  <meta name="author" content="Brigitte Jellinek"> 
-  <meta name="description" content="Ein Lehrbuch für das Informatik- oder Medieninformatik-Studium."> 
 
-  <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0;">
+  <meta name="author" content="Brigitte Jellinek">
+  <meta name="description" content="Ein Lehrbuch für das Informatik- oder Medieninformatik-Studium.">
+
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
   <meta name="generator" content="nanoc 3.1.6">
 
   <link rel="shortcut icon" href="/assets/img/favicon.png">
@@ -32,5 +32,5 @@
       <p class="lead">Ein Lehrbuch für das Informatik oder Medien-Informatik Studium.</p>
     </div>
   </header>
-    
+
 


### PR DESCRIPTION
Bundler spuckt eine Warnung aus wenn man keine HTTPS Source verwendet.

Im viewport Element wurden `;` anstatt von den korrekten ',' verwendet.
